### PR TITLE
Container resize

### DIFF
--- a/cfn/cfn-preserv-cluster.yml
+++ b/cfn/cfn-preserv-cluster.yml
@@ -2041,13 +2041,13 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: ingestformatidentifier
         Name: formatidentifier
-      Cpu: "256"
+      Cpu: !If [IsStaging,"256","512"]
       TaskRoleArn:
         Fn::ImportValue: !Sub "FargateIAMRole-${DNS}"
       ExecutionRoleArn:
         Fn::ImportValue: !Sub "ECSServiceRole-${DNS}"
       Family: !Sub 'formatidentifier-${FamTag}'
-      Memory: "512"
+      Memory: !If [IsStaging,"512","1024"]
       NetworkMode: awsvpc
       RequiresCompatibilities:
       - FARGATE
@@ -2479,13 +2479,13 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: ingestuploader
         Name: uploader
-      Cpu: "1024"
+      Cpu: !If [IsStaging,"256","1024"]
       TaskRoleArn:
         Fn::ImportValue: !Sub "FargateIAMRole-${DNS}"
       ExecutionRoleArn:
         Fn::ImportValue: !Sub "ECSServiceRole-${DNS}"
       Family: !Sub 'uploader-${FamTag}'
-      Memory: "2048"
+      Memory: !If [IsStaging,"512","2048"]
       NetworkMode: awsvpc
       RequiresCompatibilities:
       - FARGATE
@@ -3133,13 +3133,13 @@ Resources:
             awslogs-region: !Ref AWS::Region
             awslogs-stream-prefix: staginguploader
         Name: staginguploader
-      Cpu: "1024"
+      Cpu: !If [IsStaging,"256","1024"]
       TaskRoleArn:
         Fn::ImportValue: !Sub "FargateIAMRole-${DNS}"
       ExecutionRoleArn:
         Fn::ImportValue: !Sub "ECSServiceRole-${DNS}"
       Family: !Sub 'staginguploader-${FamTag}'
-      Memory: "2048"
+      Memory: !If [IsStaging,"512","2048"]
       NetworkMode: awsvpc
       RequiresCompatibilities:
       - FARGATE

--- a/cfn/cfn-preserv-cluster.yml
+++ b/cfn/cfn-preserv-cluster.yml
@@ -3680,7 +3680,7 @@ Resources:
   ScaleUpFormatIdPolicy:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
-      PolicyName: !Sub '${erService}CPUScaleUpPolicy'
+      PolicyName: !Sub '${erService}MemoryScaleUpPolicy'
       PolicyType: StepScaling
       ScalingTargetId: !Ref AutoScalingFormatIdTarget
       StepScalingPolicyConfiguration:

--- a/cfn/cfn-preserv-cluster.yml
+++ b/cfn/cfn-preserv-cluster.yml
@@ -3966,7 +3966,7 @@ Resources:
             ScalingAdjustment: 1
           - MetricIntervalLowerBound: 400
             #MetricIntervalUpperBound: 1200
-            ScalingAdjustment: 2  
+            ScalingAdjustment: 2 
 
   ScaleDownFixityPolicy:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy


### PR DESCRIPTION
As production gets busier, there was a need to increase container sizes, but to maintain the smaller stance for staging and demo to minimize usage. This update is to address those changes. They have been tested.