### PR TITLE
Filename character encoding - amendment

### DIFF
--- a/ingest/staging_uploader.go
+++ b/ingest/staging_uploader.go
@@ -120,7 +120,7 @@ func (s *StagingUploader) CopyFileToStaging(tarReader *tar.Reader, ingestFile *s
 	bucket := s.Context.Config.StagingBucket
 	key := s.S3KeyFor(ingestFile)
 
-	// Work-around for narrow non-breaking space bug. https://trello.com/c/
+	// Work-around for narrow non-breaking space bug. https://trello.com/c/euql70E3
 	// For a case where a narrow non-breaking space is included in the file path, use bagpath-encoded header. For all others, use bagpath.
 	// Note that UserMetadata initially contains both.
 	if strings.Contains(ingestFile.PathInBag, constants.NarrowNonBreakingSpace) {


### PR DESCRIPTION
See https://github.com/APTrust/preservation-services/pull/175 for the original fix context.

The fix for this (removing "Bagpath" header) also needs to be applied when we upload to a staging bucket, as evidenced by an error seen on the Work Item. Ingest failed at Step 04, Staging Upload. This is just applying the original fix to that step also.