### PR TITLE
Linux test updates

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -6,7 +6,7 @@ services:
     command: /nsqlookupd
     # platform: linux/arm64
     volumes:
-      - ~/tmp/nsq/nsqlookupd:/data
+      - nsqlookupd_data:/data
     ports:
       - "4160:4160"
       - "4161:4161"
@@ -20,7 +20,7 @@ services:
     command: /nsqd --data-path=/data --lookupd-tcp-address=nsqlookupd:4160 --broadcast-address=localhost
     # platform: linux/arm64
     volumes:
-      - ~/tmp/nsq/nsqd:/data
+      - nsqd_data:/data
     depends_on:
       - nsqlookupd
     ports:
@@ -49,6 +49,7 @@ services:
 
   minio:
     image: quay.io/minio/minio
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-1000}"
     command: server /data --console-address ":9001"
     # platform: linux/arm64
     environment:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -101,6 +101,13 @@ setup_env() {
   fi
   export APT_CONFIG_DIR="$PROJECT_ROOT"
   export APT_ENV=test
+  # Ensure docker-compose-local bind mounts are written as the invoking user.
+  # Otherwise, files created by the services will be owned by root and the
+  # invoking user won't be able to delete them.
+  export LOCAL_UID
+  LOCAL_UID="$(id -u)"
+  export LOCAL_GID
+  LOCAL_GID="$(id -g)"
   if [[ "$TEST_NAME" == "e2e" ]]; then
     export APT_E2E=true
   fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -235,6 +235,12 @@ stop_all_services() {
   SERVICES_STOPPED=true
 }
 
+# Start each test run with a clean Compose state.
+# NSQ topic/message depth persistence can cause e2e wait checks to pass early.
+reset_local_compose() {
+  (cd "$PROJECT_ROOT" && docker-compose -f docker-compose-local.yml down -v --remove-orphans) || true
+}
+
 # Starts all ingest worker services. Pass any extra service names as arguments.
 start_ingest_services() {
   local -a names=(
@@ -349,6 +355,7 @@ init_for_integration() {
   make_test_dirs
   registry_start
   sleep 8
+  reset_local_compose
   (cd "$PROJECT_ROOT" && docker-compose -f docker-compose-local.yml up -d)
   sleep 5
   create_nsq_topics
@@ -377,6 +384,7 @@ run_unit_tests() {
   local arg="${1:-}"
   clean_test_cache
   make_test_dirs
+  reset_local_compose
   (cd "$PROJECT_ROOT" && docker-compose -f docker-compose-local.yml up -d)
   run_go_unit_tests "$arg"
   # EXIT trap will stop all services


### PR DESCRIPTION
These commits fix some problems in running the preservation services integration and end-to-end tests on Debian-derived Linux systems. All tests are passing on Debian Linux. Be sure they pass on MacOS as well.